### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 description = "A C POSIX library in Rust"
 license = "MIT"
+repository = "https://github.com/fathyb/po6"
 
 [workspace]
 resolver = "2"


### PR DESCRIPTION
to allow crates.io, rust-digger, and others to link to it